### PR TITLE
Add Global gitignore

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,15 +14,23 @@ require 'yaml'
 ########################
 # Supporting Libraries
 class Installfest
+  class CommandResult
+    attr_reader :status, :message
+    def initialize(status, message)
+      @status = !!status
+      @message = message
+    end
+  end
+
   # TODO: extract Package
   def assert(boolean_expression, failure_message_for_actual, failure_message_for_expected)
     if boolean_expression
-      return OpenStruct.new( status: true, message: 'met' )
+      return CommandResult.new(true, 'met')
     else
       message = colorize("FAIL", :red)
       message += "\n  #{failure_message_for_actual}"
       message += "\n  #{failure_message_for_expected}"
-      return OpenStruct.new( status: false, message: message )
+      return CommandResult.new(false, message)
     end
   end
 
@@ -832,6 +840,23 @@ if $PROGRAM_NAME == __FILE__
         ENV['EDITOR'] = 'subl'
         @installfest.packages.keys.must_include :sublime
       end
+    end
+  end
+
+  describe Installfest::CommandResult do
+    before do
+      @result = Installfest::CommandResult.new(true, "MESSAGE")
+    end
+
+    it "responds to #status" do
+      @result.status.must_equal(true)
+    end
+    it "responds to #message" do
+      @result.message.must_equal("MESSAGE")
+    end
+
+    it "converts status to boolean" do
+      Installfest::CommandResult.new(nil, "MESSAGE").status.must_equal(false)
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ class Installfest
     if boolean_expression
       return CommandResult.new(true, 'met')
     else
-      message = colorize("FAIL", :red)
+      message = colorize("Expectation NOT met", :red)
       message += "\n  #{failure_message_for_actual}"
       message += "\n  #{failure_message_for_expected}"
       return CommandResult.new(false, message)
@@ -813,7 +813,7 @@ if $PROGRAM_NAME == __FILE__
           out, err = capture_io do
             result = @installfest.assert(false, 'test_actual', 'test_expected')
           end
-          assert_match(/FAIL/i, result.message)
+          assert_match(/NOT met/i, result.message)
         end
 
         it "notifies the user, unless ENV['VERBOSE'] == 'false'" do

--- a/Rakefile
+++ b/Rakefile
@@ -302,8 +302,31 @@ We use information from your github account throughout the class.
         verify: -> { assert(!github_username.to_s.empty?, "We can't find your github username.", "") }
       },
 
+      global_gitignore: {
+        header: "Register a global gitignore file",
+        installation_steps: [
+          %q(
+1. Backup your existing global_gitignore (if it exists).  You can ignore a "No such file or directory" error:
+
+    $ mv ~/.gitignore_global ~/.gitignore_global.bak
+
+2. Download the provided global gitignore file to your home dir:
+
+    $ curl -sSL https://raw.githubusercontent.com/ga-dc/installfest/master/support/gitignore_global -o ~/.gitignore_global
+
+3. Configure git to use this global gitignore file:
+
+    $ git config --global core.excludesfile ~/.gitignore_global
+          )
+        ],
+        verify: -> {
+          assert_match(/\.DS\_Store/, 'cat ~/.gitignore_global | grep "DS_Store"') &&
+          assert_match(/Users\/.*\/.gitignore_global/, 'git config --global --list | grep core.excludesfile')
+        }
+      },
+
       homebrew: {
-        header: %q(Homebrew (OSX's Package Manager)),
+        header: "Homebrew (OSX's Package Manager)",
         installation_steps: [
           %q(
 1. Download and install Homebrew:

--- a/installfest.md
+++ b/installfest.md
@@ -125,7 +125,7 @@ If you installed node without using 'brew install node', follow these instructio
 
 1. Download Postgres.app from www.postgresapp.com
 2. Move the Postgres.app to your 'Applications' folder.
-3. Open the Postgres.app
+3. Open the Postgres.app (using "right-click + open" for this non-Mac App store app)
   -  Look for the elephant in the the menu bar.
 4. Configure bash to enable opening Postgres from the command line (via psql):
 
@@ -207,13 +207,17 @@ The output of `git --version` is greater than or equal to 2.0
 1. Personalize git
   - Your Full Name:
 
-    `$ git config --global user.name  "YOUR FULL NAME"`
+    $ git config --global user.name  "YOUR FULL NAME"
 
   - The email in your github profile (https://github.com):
 
-    `$ git config --global user.email "THE_EMAIL_YOU_USE_FOR_GITHUB@EMAIL.COM"`
+    $ git config --global user.email "THE_EMAIL_YOU_USE_FOR_GITHUB@EMAIL.COM"
 
-2. Configure git's colors (you can copy & paste all of these commands at once):
+2. Configure the default push mode:
+
+    $ git config --global push.default simple
+
+3. Configure git's colors (you can copy & paste all of these commands at once):
 
     git config --global color.ui always
     git config --global color.branch.current   "green reverse"
@@ -234,6 +238,22 @@ The output of `git --version` is greater than or equal to 2.0
   3b. OR, if you are using atom (the default):
 
     $ git config --global core.editor "atom --wait"
+          
+
+
+## Register a global gitignore file
+
+1. Backup your existing global_gitignore (if it exists).  You can ignore a "No such file or directory" error:
+
+    $ mv ~/.gitignore_global ~/.gitignore_global.bak
+
+2. Download the provided global gitignore file to your home dir:
+
+    $ curl -sSL https://raw.githubusercontent.com/ga-dc/installfest/master/support/gitignore_global -o ~/.gitignore_global
+
+3. Configure git to use this global gitignore file:
+
+    $ git config --global core.excludesfile ~/.gitignore_global
           
 
 

--- a/installfest_dc_wdi.yml
+++ b/installfest_dc_wdi.yml
@@ -12,6 +12,7 @@
 - :slack
 - :git
 - :git_configuration
+- :global_gitignore
 - :github
 - :bash_prompt
 - :authorize_wdi

--- a/support/gitignore_global
+++ b/support/gitignore_global
@@ -1,0 +1,36 @@
+# >>>>>>>>>>>>>>>>>>>
+# Content from https://raw.githubusercontent.com/github/gitignore/master/Global/OSX.gitignore
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://raw.githubusercontent.com/github/gitignore/master/Global/OSX.gitignore
+# <<<<<<<<<<<<<<<<<<<<<<<<
+
+# >>>>>>>>>>>>>>>>>>>>>>>>
+# Start of content Added by GA
+
+# node #
+node_modules/
+bower_components/


### PR DESCRIPTION
- adds step: global_gitignore
  - checks for existence of random item in ~/.gitignore_global (.DS_Store) AND appropriate git config.
- Uses support/gitignore_global file.
- Converted OpenStruct to CommandResult class.  This is more explicit and supports #merge (to support multiple verifies).
- minor improvement to Failure flag (FAIL -> "Expectation NOT met")

Instructors should be able to run `rake installfest:doctor` and/or `rake installfest:start` to test.
