### PR TITLE
fixes #28, wdi config: remove disable_system_integrity_protection

### DIFF
--- a/installfest_dc_wdi.yml
+++ b/installfest_dc_wdi.yml
@@ -1,6 +1,5 @@
 ---
 
-- :disable_system_integrity_protection
 - :atom
 - :xcode_cli_tools
 - :uninstall_non_brew_node


### PR DESCRIPTION
Simply updates config.  Removal of SIP, for El Capitan, is no longer required.
