### PR TITLE
Pass brew dr warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,13 +84,15 @@ class Installfest
   def assert_no_errors(shell_command)
     begin
       value = `#{shell_command} 2>&1`.chomp
+      ready = /ready to brew\.$/ =~ value
       error = /^Error:/ =~ value
-      if /^Warning:/ =~ value
+      warning = /^Warning:/ =~ value
+      if warning
         print_warning value
       end
-      assert !error,
+      assert ready || warning && !error,
              "Actual result: '#{value}' (via `#{shell_command}`)",
-             "Should have no errors"
+             "Should be ready to brew or have no errors"
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -186,7 +186,7 @@ class Installfest
         installation_steps: [
           %q(
 
-1. Go to https://garnet.wdidc.org/github/authorize?invite_code=74cf1bf5af493e65e85408899ca397cf
+1. Go to https://garnet.wdidc.org/github/authorize?invite_code=cbfe54d86f611769046d1ef17afc011a
 
 2. Click "Authorize Application" to allow GA to access to your public information.
         )],


### PR DESCRIPTION
This checks `brew doctor` output for either "ready to brew" or "Warning" and no "Error".

Could still add:
- [ ] update `assert` method to accommodate "pass with warnings"
- [ ] fix tests (not running in CI) / add test for changes
- [ ] check version and separately for errors